### PR TITLE
fix: bugs in dev:kind:create script

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,9 @@
 				"ms-kubernetes-tools.vscode-kubernetes-tools",
 				"redhat.vscode-yaml",
 				"yzhang.markdown-all-in-one",
-				"Gruntfuggly.todo-tree"
+				"Gruntfuggly.todo-tree",
+				"astro-build.astro-vscode",
+				"svelte.svelte-vscode"
 			]
 		}
 	}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,11 @@
 			"minikube": "none"
 		},
 		"ghcr.io/mpriscella/features/kind:1": {},
-		"ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {}
+		"ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {
+      "jqVersion": "none",
+      "yqVersion": "latest",
+      "gojqVersion": "none"
+    }
 	},
 	"customizations": {
 		"vscode": {

--- a/README.md
+++ b/README.md
@@ -78,26 +78,27 @@ pnpm start
 
 All commands are run from the root of the project, from a terminal:
 
-| Command                                  | Action                                                                                                         |
-| :--------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| `pnpm install`                           | Installs dependencies                                                                                          |
-| `pnpm dev:astro`                         | Starts local [Astro](https://astro.build/) dev server at `localhost:3000` for the frontend of the SKF website  |
-| `pnpm build:astro`                       | Build the production site to `./packages/astro/dist/`                                                          |
-| `pnpm start:astro`                       | Preview the site locally, before deploying                                                                     |
-| `pnpm --filter=astro astro ...`          | Run CLI commands like `astro add`, `astro check`                                                               |
-| `pnpm --filter=astro astro --help`       | Get help using the Astro CLI                                                                                   |
-| `pnpm --filter=astro format`             | Formats code for the Astro frontend                                                                            |
-| `pnpm --filter=astro fix:lint`           | Lints & Fixes code for the Astro frontend                                                                      |
-| `pnpm docker`                            | Builds the docker container for `astro` & `workers`                                                            |
-| `pnpm docker:astro`                      | Builds the docker container for only `astro`                                                                   |
-| `pnpm docker:workers`                    | Builds the docker container for only `workers`                                                                 |
-| `pnpm kind:create`                       | Create's `kind` and sets up the kubernetes config file (`./k8s/kubeconf`) the `workers` docker container needs |
-| `pnpm start`                             | Start the `astro`, `workers`, and `rabbitmq` docker containers in kubernetes                                   |
-| `pnpm --filter=workers -- deno ...`      | Run CLI commands like `deno run -A ./hello.ts`, `deno lint`, etc..                                             |
-| `pnpm --filter=workers -- deno --help`   | Get help using Deno                                                                                            |
-| `pnpm --filter=workers -- deno fmt`      | Formats code for the Deno workers                                                                              |
-| `pnpm --filter=astro -- deno lint`       | Lints code for the Deno workers                                                                                |
-| `pnpm --filter=astro -- deno task hello` | Runs the `hello` task script in the [./packages/workers/deno.jsonc](./packages/workers/deno.jsonc)             |
+| Command                                  | Action                                                                                                                                 |
+| :--------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm install`                           | Installs dependencies                                                                                                                  |
+| `pnpm dev:astro`                         | Starts local [Astro](https://astro.build/) dev server at `localhost:3000` for the frontend of the SKF website                          |
+| `pnpm build:astro`                       | Build the production site to `./packages/astro/dist/`                                                                                  |
+| `pnpm start:astro`                       | Preview the site locally, before deploying                                                                                             |
+| `pnpm --filter=astro astro ...`          | Run CLI commands like `astro add`, `astro check`                                                                                       |
+| `pnpm --filter=astro astro --help`       | Get help using the Astro CLI                                                                                                           |
+| `pnpm --filter=astro format`             | Formats code for the Astro frontend                                                                                                    |
+| `pnpm --filter=astro fix:lint`           | Lints & Fixes code for the Astro frontend                                                                                              |
+| `pnpm docker`                            | Builds the docker container for `astro` & `workers`                                                                                    |
+| `pnpm docker:astro`                      | Builds the docker container for only `astro`                                                                                           |
+| `pnpm docker:workers`                    | Builds the docker container for only `workers`                                                                                         |
+| `pnpm kind:create`                       | Create's `kind` cluster for production and sets up the kubernetes config file (`./k8s/kubeconf`) the `workers` docker container needs  |
+| `pnpm dev:kind:create`                   | Create's `kind` cluster for development and sets up the kubernetes config file (`./k8s/kubeconf`) the `workers` docker container needs |
+| `pnpm start`                             | Start the `astro`, `workers`, and `rabbitmq` docker containers in kubernetes                                                           |
+| `pnpm --filter=workers -- deno ...`      | Run CLI commands like `deno run -A ./hello.ts`, `deno lint`, etc..                                                                     |
+| `pnpm --filter=workers -- deno --help`   | Get help using Deno                                                                                                                    |
+| `pnpm --filter=workers -- deno fmt`      | Formats code for the Deno workers                                                                                                      |
+| `pnpm --filter=astro -- deno lint`       | Lints code for the Deno workers                                                                                                        |
+| `pnpm --filter=astro -- deno task hello` | Runs the `hello` task script in the [./packages/workers/deno.jsonc](./packages/workers/deno.jsonc)                                     |
 
 ## FAQ
 ### Kind

--- a/README.md
+++ b/README.md
@@ -73,6 +73,35 @@ Step 3. Start `kubernetes`
 pnpm start
 ```
 
+## Developing Locally
+
+Step 1. Create cluster (development)
+
+```sh
+pnpm dev:kind:create
+```
+
+Step 2. Run `rabbitmq` in a separate terminal
+
+```sh
+pnpm start:rabbitmq
+```
+
+Step 3. Run `astro` in a separate terminal (development)
+
+```sh
+pnpm dev:astro
+```
+
+Step 4. Run `workers` in a separate terminal (development) (you may need to wait till `rabbitmq` is ready)
+
+```sh
+pnpm start:workers
+```
+
+To test out if the `workers` are working, properly go to the Astro website at [`localhost:3000`](http://localhost:3000) and login.
+
+Once logged in, go to this URL [`localhost:3000/api/labs/deployments/1`](http://localhost:3000/api/labs/deployments/1) and you should see a message with a port number, if the response takes longer than 1 minute then the `workers` are not working properly, you need to kill all the development processes, you'll then have to restart the development process from Step 2 onward.
 
 ## 🧞 Commands
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "docker": "pnpm docker:astro && pnpm docker:workers; kind load docker-image workers:skf astro:skf",
     "docker:workers": "docker build -t workers:skf -f ./packages/workers/Dockerfile --target prod . --no-cache",
     "docker:astro": "docker build -t astro:skf -f ./packages/astro/Dockerfile --target dev . --no-cache",
-    "kind:create": "sh ./scripts/cluster-create-sh.sh"
+    "kind:create": "sh ./scripts/cluster-create-sh.sh",
+    "dev:kind:create": "sh ./scripts/cluster-create-sh.sh"
   },
   "devDependencies": {
     "typescript": "^4.9.5"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "docker:workers": "docker build -t workers:skf -f ./packages/workers/Dockerfile --target prod . --no-cache",
     "docker:astro": "docker build -t astro:skf -f ./packages/astro/Dockerfile --target dev . --no-cache",
     "kind:create": "sh ./scripts/cluster-create-sh.sh",
-    "dev:kind:create": "sh ./scripts/cluster-create-sh.sh"
+    "dev:kind:create": "sh ./scripts/dev-cluster-create-sh.sh"
   },
   "devDependencies": {
     "typescript": "^4.9.5"

--- a/scripts/cluster-create-sh.sh
+++ b/scripts/cluster-create-sh.sh
@@ -9,11 +9,8 @@ kubectl cluster-info --context kind-kind
 cp /home/node/.kube/config ./k8s/kubeconf
 
 #replace ip+port to https://kubernetes
-FILE=./k8s/kubeconf
-if [[ -f "$FILE" ]]; then
-  yq -i '
-    .clusters[0].cluster.server = "https://kubernetes" | 
-    .networking.mode = "host-bridge" 
-  ' ./k8s/kubeconf
-fi
+yq -i '
+  .clusters[0].cluster.server = "https://kubernetes" | 
+  .networking.mode = "host-bridge" 
+' ./k8s/kubeconf
 

--- a/scripts/dev-cluster-create-sh.sh
+++ b/scripts/dev-cluster-create-sh.sh
@@ -7,13 +7,10 @@ kubectl cluster-info --context kind-kind
 
 #copy kube config file so we can use it inside the workers container
 cp /home/node/.kube/config ./k8s/kubeconf
-find ./k8s/kubeconf -type f -exec sed -i -e "s,https://127.0.0.1:.*,https://localhost,g" {} \;
+find ./k8s/kubeconf -type f -exec sed -i -e "s,https://127.0.0.1,https://localhost,g" {} \;
 
 #replace ip+port to https://kubernetes
-FILE=./k8s/kubeconf
-if [[ -f "$FILE" ]]; then
-  yq -i '
-    .networking.mode = "host-bridge" 
-  ' ./k8s/kubeconf
-fi
+yq -i '
+  .networking.mode = "host-bridge" 
+' ./k8s/kubeconf
 

--- a/scripts/dev-cluster-create-sh.sh
+++ b/scripts/dev-cluster-create-sh.sh
@@ -14,3 +14,5 @@ yq -i '
   .networking.mode = "host-bridge" 
 ' ./k8s/kubeconf
 
+touch ./packages/workers/.env
+echo "KUBECONFIG=$(realpath ./k8s/kubeconf)" >> ./packages/workers/.env

--- a/scripts/dev-cluster-create-sh.sh
+++ b/scripts/dev-cluster-create-sh.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+kind delete cluster
+kind create cluster --wait 5m 
+kind get clusters 
+kubectl cluster-info --context kind-kind
+
+#copy kube config file so we can use it inside the workers container
+cp /home/node/.kube/config ./k8s/kubeconf
+find ./k8s/kubeconf -type f -exec sed -i -e "s,https://127.0.0.1:.*,https://localhost,g" {} \;
+
+#replace ip+port to https://kubernetes
+FILE=./k8s/kubeconf
+if [[ -f "$FILE" ]]; then
+  yq -i '
+    .networking.mode = "host-bridge" 
+  ' ./k8s/kubeconf
+fi
+


### PR DESCRIPTION
Check commit history for list of changes 

Summary: 
* Install `yq` into devcontainer
* Remove check for `./k8s/kubeconf` file existing `yq` (if `./k8s/kubeconf` doesn't exist, then something has gone wrong and it's better to know early)
* On `dev:kind:create` [add a .env to workers](https://github.com/Security-Knowledge-Framework/skf-examination-platform/commit/8bb74150cc0a97c284526da509a97749b88b24d8)
* Update docs....
