### PR TITLE
Fuzzy Fix: Hoisted `env` keys to `Deno.env`

### DIFF
--- a/packages/workers/kubernetes.ts
+++ b/packages/workers/kubernetes.ts
@@ -39,7 +39,7 @@ import { config } from '@skf/shared/config.ts';
 import rascal from 'rascal';
 const { createBrokerAsPromised } = rascal;
 
-const env = await dotenv();
+const env = await dotenv({export: true});
 
 function getEnv(name: string) { 
   return env[name] ?? Deno.env.get(name);

--- a/packages/workers/kubernetes.ts
+++ b/packages/workers/kubernetes.ts
@@ -31,7 +31,7 @@ import {
   fromDeploymentSpec, toDeploymentSpec,
   fromDeployment, toDeployment
 } from 'https://deno.land/x/kubernetes_apis/builtin/apps@v1/mod.ts';
-import { load as dotenv } from "https://deno.land/std/dotenv/mod.ts";
+import { load } from "https://deno.land/std@0.178.0/dotenv/mod.ts";
 
 import { config } from '@skf/shared/config.ts';
 
@@ -39,10 +39,10 @@ import { config } from '@skf/shared/config.ts';
 import rascal from 'rascal';
 const { createBrokerAsPromised } = rascal;
 
-const env = await dotenv({export: true});
+await load({export: true});
 
 function getEnv(name: string) { 
-  return env[name] ?? Deno.env.get(name);
+  return Deno.env.get(name);
 }
 console.log({ host: getEnv("KUBERNETES_HOST"), HOME: getEnv("HOME"), envlist: Deno.env.toObject() })
 

--- a/packages/workers/port-forward.ts
+++ b/packages/workers/port-forward.ts
@@ -2,12 +2,12 @@ import { Reflector, KubeConfigRestClient, ClientProviderChain, KubectlRawRestCli
 import type { RestClient } from 'https://deno.land/x/kubernetes_client/mod.ts';
 import type { Service } from 'https://deno.land/x/kubernetes_apis/builtin/core@v1/structs.ts';
 import { CoreV1Api } from "https://deno.land/x/kubernetes_apis/builtin/core@v1/mod.ts";
-import { load as dotenv } from "https://deno.land/std/dotenv/mod.ts";
+import { load } from "https://deno.land/std@0.178.0/dotenv/mod.ts";
 
-const env = await dotenv();
+await load({export:true})
 
 function getEnv(name: string) { 
-  return env[name] ?? Deno.env.get(name);
+  return Deno.env.get(name);
 }
 console.log({ host: getEnv("KUBERNETES_HOST"), HOME: getEnv("HOME"), envlist: Deno.env.toObject() })
 


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1qWBHbKGCZervT6gkGioiCfWNXDN38Ejg%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=fSIOQvJ)

This PR provides a fix for the way we were previously obtaining the `env` keys during the creation of the `kubernetes` and `port-forwarding` scripts. 

Here we hoisted the keys directly to the `Deno.env` global, by using the `await load({export:true}` 

This was applied to both `kubernetes.ts` and `port-forward.ts` 